### PR TITLE
feat: add alert history — model, API, and dashboard page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import ConnectAws from './pages/ConnectAws';
 import AddServer from './pages/AddServer';
 import LogsViewer from './pages/LogsViewer';
 import SetupWizard from './pages/SetupWizard';
+import AlertHistory from './pages/AlertHistory';
 
 // Auth Guard component
 const ProtectedRoute = ({ children }) => {
@@ -53,6 +54,7 @@ function App() {
           <Route path="/aws" element={<WithLayout component={ConnectAws} />} />
           <Route path="/servers" element={<WithLayout component={AddServer} />} />
           <Route path="/logs" element={<WithLayout component={LogsViewer} />} />
+          <Route path="/alerts" element={<WithLayout component={AlertHistory} />} />
           
           {/* 404 */}
           <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/frontend/src/components/layout/DashboardLayout.jsx
+++ b/frontend/src/components/layout/DashboardLayout.jsx
@@ -12,6 +12,7 @@ import {
   Lock,
   ChevronDown,
   ChevronRight,
+  BellRing,
 } from 'lucide-react';
 import clsx from 'clsx';
 import api from '../../lib/api';
@@ -19,6 +20,7 @@ import api from '../../lib/api';
 const baseNavItems = [
   { name: 'Overview', path: '/dashboard', icon: LayoutDashboard },
   { name: 'Logs Viewer', path: '/logs', icon: TerminalSquare, requiresSetup: true },
+  { name: 'Alert History', path: '/alerts', icon: BellRing, requiresSetup: true },
   { name: 'AWS Accounts', path: '/aws', icon: Cloud },
   { name: 'Servers', path: '/servers', icon: Server },
   { name: 'Setup Wizard', path: '/setup', icon: Wand2, highlight: true },

--- a/frontend/src/pages/AlertHistory.jsx
+++ b/frontend/src/pages/AlertHistory.jsx
@@ -1,0 +1,235 @@
+import { useState, useEffect } from 'react';
+import api from '../lib/api';
+import { BellRing, ChevronDown, ChevronUp, RefreshCw, Bot, Terminal } from 'lucide-react';
+import clsx from 'clsx';
+import { formatDistanceToNow, format } from 'date-fns';
+
+const SEVERITY_STYLES = {
+  critical: 'text-red-400 bg-red-400/10 border-red-400/30',
+  high:     'text-orange-400 bg-orange-400/10 border-orange-400/30',
+  medium:   'text-yellow-400 bg-yellow-400/10 border-yellow-400/30',
+};
+
+function AlertCard({ alert }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasAi = !!alert.aiCause;
+  const severityStyle = SEVERITY_STYLES[alert.aiSeverity] || SEVERITY_STYLES.high;
+
+  return (
+    <div className="bg-surface border border-border rounded-xl overflow-hidden transition-all">
+      {/* Header row */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between px-5 py-4 hover:bg-surface-hover transition-colors text-left"
+      >
+        <div className="flex items-center gap-4 min-w-0">
+          {/* Severity / error badge */}
+          <span className={clsx(
+            'shrink-0 px-2.5 py-1 rounded-md text-xs font-bold border uppercase tracking-wide',
+            severityStyle
+          )}>
+            {alert.aiSeverity || 'error'}
+          </span>
+
+          {/* Error count */}
+          <span className="shrink-0 text-sm font-semibold text-white">
+            {alert.errorCount} error{alert.errorCount !== 1 ? 's' : ''}
+          </span>
+
+          {/* AI cause preview */}
+          {hasAi && (
+            <span className="text-sm text-muted truncate hidden sm:block">
+              {alert.aiCause}
+            </span>
+          )}
+
+          {/* AI badge */}
+          {hasAi && (
+            <span className="shrink-0 flex items-center gap-1 text-xs text-primary/70 bg-primary/10 px-2 py-0.5 rounded">
+              <Bot className="w-3 h-3" /> AI
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-4 shrink-0 ml-4">
+          <div className="text-right hidden sm:block">
+            <p className="text-xs text-muted">
+              {formatDistanceToNow(new Date(alert.firedAt), { addSuffix: true })}
+            </p>
+            <p className="text-xs text-muted/50">
+              {format(new Date(alert.firedAt), 'MMM d, HH:mm:ss')}
+            </p>
+          </div>
+          {expanded
+            ? <ChevronUp className="w-4 h-4 text-muted" />
+            : <ChevronDown className="w-4 h-4 text-muted" />}
+        </div>
+      </button>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="border-t border-border px-5 py-4 space-y-4">
+
+          {/* AI Analysis block */}
+          {hasAi && (
+            <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
+              <p className="text-xs font-semibold text-primary/70 uppercase tracking-wider flex items-center gap-1.5">
+                <Bot className="w-3.5 h-3.5" /> AI Analysis — Gemini 2.0 Flash
+              </p>
+              {alert.aiSummary && (
+                <p className="text-sm text-gray-300">{alert.aiSummary}</p>
+              )}
+              <div>
+                <p className="text-xs text-muted uppercase mb-1">Root Cause</p>
+                <p className="text-sm text-white">{alert.aiCause}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted uppercase mb-1">Suggested Fix</p>
+                <code className="block bg-[#0A0E17] text-green-400 text-xs font-mono px-3 py-2 rounded border border-border">
+                  {alert.aiFix}
+                </code>
+              </div>
+            </div>
+          )}
+
+          {/* Sample log messages */}
+          {alert.sampleMessages?.length > 0 && (
+            <div>
+              <p className="text-xs text-muted uppercase mb-2 flex items-center gap-1.5">
+                <Terminal className="w-3.5 h-3.5" /> Sample Logs
+              </p>
+              <div className="bg-[#0A0E17] rounded-lg border border-border p-3 space-y-1.5 font-mono text-xs">
+                {alert.sampleMessages.map((msg, i) => (
+                  <div key={i} className="flex gap-2">
+                    <span className="text-red-400 shrink-0">ERR</span>
+                    <span className="text-gray-300 break-all">{msg}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Meta */}
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted pt-1">
+            <span>Email sent to: <span className="text-white">{alert.emailSentTo || '—'}</span></span>
+            <span>Queued: <span className={alert.emailQueued ? 'text-green-400' : 'text-red-400'}>{alert.emailQueued ? 'Yes' : 'No'}</span></span>
+            <span>Time: <span className="text-white">{format(new Date(alert.firedAt), 'PPpp')}</span></span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AlertHistory() {
+  const [alerts, setAlerts]   = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+  const [page, setPage]       = useState(1);
+  const [meta, setMeta]       = useState(null);
+
+  const fetchAlerts = async (p = 1) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.get(`/alerts?page=${p}&limit=20`);
+      setAlerts(res.data.data || []);
+      setMeta(res.data.meta || null);
+      setPage(p);
+    } catch (err) {
+      setError('Failed to load alert history.');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchAlerts(1); }, []);
+
+  return (
+    <div className="space-y-6 max-w-4xl mx-auto">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white tracking-tight flex items-center">
+            <BellRing className="w-7 h-7 mr-3 text-primary" />
+            Alert History
+          </h1>
+          <p className="text-sm text-muted mt-1 ml-10">
+            Every alert fired for your workspace — with AI analysis
+          </p>
+        </div>
+        <button
+          onClick={() => fetchAlerts(page)}
+          disabled={loading}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-surface border border-border text-sm text-muted hover:text-white transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={clsx('w-4 h-4', loading && 'animate-spin')} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats strip */}
+      {meta && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div className="bg-surface border border-border rounded-xl px-4 py-3">
+            <p className="text-xs text-muted uppercase tracking-wider">Total Alerts</p>
+            <p className="text-2xl font-bold text-white mt-1">{meta.total}</p>
+          </div>
+          <div className="bg-surface border border-border rounded-xl px-4 py-3">
+            <p className="text-xs text-muted uppercase tracking-wider">This Page</p>
+            <p className="text-2xl font-bold text-white mt-1">{alerts.length}</p>
+          </div>
+          <div className="bg-surface border border-border rounded-xl px-4 py-3">
+            <p className="text-xs text-muted uppercase tracking-wider">AI Analysed</p>
+            <p className="text-2xl font-bold text-primary mt-1">
+              {alerts.filter(a => a.aiCause).length}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Alert list */}
+      {loading ? (
+        <div className="text-center text-muted py-16">Loading alert history...</div>
+      ) : error ? (
+        <div className="text-center text-danger py-16">{error}</div>
+      ) : alerts.length === 0 ? (
+        <div className="text-center py-16 flex flex-col items-center gap-3">
+          <BellRing className="w-10 h-10 text-muted opacity-30" />
+          <p className="text-muted">No alerts fired yet.</p>
+          <p className="text-muted/50 text-sm">Alerts appear here when ERROR or FATAL logs are detected.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {alerts.map((alert) => (
+            <AlertCard key={alert._id} alert={alert} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {meta && meta.totalPages > 1 && (
+        <div className="flex justify-center items-center gap-3 pt-2">
+          <button
+            disabled={page <= 1 || loading}
+            onClick={() => fetchAlerts(page - 1)}
+            className="px-4 py-2 rounded-lg bg-surface border border-border text-sm text-muted hover:text-white disabled:opacity-40 transition-colors"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-muted">
+            Page {page} of {meta.totalPages}
+          </span>
+          <button
+            disabled={page >= meta.totalPages || loading}
+            onClick={() => fetchAlerts(page + 1)}
+            className="px-4 py-2 rounded-lg bg-surface border border-border text-sm text-muted hover:text-white disabled:opacity-40 transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/opsentra/src/controllers/alertController.js
+++ b/opsentra/src/controllers/alertController.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const AlertLog = require('../models/AlertLog');
+const Workspace = require('../models/Workspace');
+const catchAsync = require('../utils/catchAsync');
+const AppError = require('../utils/AppError');
+const { sendSuccess } = require('../utils/apiResponse');
+
+/**
+ * Resolve the caller's workspace (same helper pattern as logController).
+ */
+const resolveWorkspaceId = async (req) => {
+  const wsId = req.query.workspace_id;
+  if (wsId) return wsId;
+
+  const ws = await Workspace.findOne({ userId: req.user._id, isActive: true })
+    .sort({ createdAt: 1 })
+    .lean();
+  if (!ws) throw AppError.notFound('No active workspace found');
+  return ws._id.toString();
+};
+
+/**
+ * @route  GET /api/v1/alerts
+ * @access Protected
+ * @query  workspace_id?, page?, limit?
+ *
+ * Returns paginated alert history for a workspace, newest first.
+ */
+const getAlertHistory = catchAsync(async (req, res) => {
+  const workspaceId = await resolveWorkspaceId(req);
+  const page  = Math.max(1, Number(req.query.page)  || 1);
+  const limit = Math.min(100, Math.max(1, Number(req.query.limit) || 20));
+  const skip  = (page - 1) * limit;
+
+  const [alerts, total] = await Promise.all([
+    AlertLog.find({ workspaceId })
+      .sort({ firedAt: -1 })
+      .skip(skip)
+      .limit(limit)
+      .lean(),
+    AlertLog.countDocuments({ workspaceId }),
+  ]);
+
+  sendSuccess(res, {
+    data: alerts,
+    meta: {
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+      workspaceId,
+    },
+  });
+});
+
+module.exports = { getAlertHistory };

--- a/opsentra/src/models/AlertLog.js
+++ b/opsentra/src/models/AlertLog.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const mongoose = require('mongoose');
+
+/**
+ * AlertLog — a record of every alert email that was attempted.
+ * Saved by alertService after each fireAlerts() call regardless of
+ * whether the email was queued or suppressed by cooldown.
+ */
+const alertLogSchema = new mongoose.Schema(
+  {
+    workspaceId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Workspace',
+      required: true,
+      index: true,
+    },
+    errorCount: {
+      type: Number,
+      required: true,
+    },
+    emailSentTo: {
+      type: String,
+      default: null,
+    },
+    emailQueued: {
+      type: Boolean,
+      default: false,
+    },
+    // First 3 raw log messages — for the history timeline
+    sampleMessages: {
+      type: [String],
+      default: [],
+    },
+    // Populated when Gemini analysis succeeded
+    aiCause: { type: String, default: null },
+    aiFix: { type: String, default: null },
+    aiSeverity: {
+      type: String,
+      enum: ['critical', 'high', 'medium', null],
+      default: null,
+    },
+    aiSummary: { type: String, default: null },
+  },
+  {
+    timestamps: { createdAt: 'firedAt', updatedAt: false },
+    collection: 'alert_logs',
+  },
+);
+
+alertLogSchema.index({ workspaceId: 1, firedAt: -1 });
+
+const AlertLog = mongoose.model('AlertLog', alertLogSchema);
+
+module.exports = AlertLog;

--- a/opsentra/src/models/index.js
+++ b/opsentra/src/models/index.js
@@ -14,6 +14,7 @@ const Workspace = require('./Workspace');
 const AwsIntegration = require('./AwsIntegration');
 const ServerInstance = require('./ServerInstance');
 const LogEntry = require('./LogEntry');
+const AlertLog = require('./AlertLog');
 
 module.exports = {
   User,
@@ -23,4 +24,5 @@ module.exports = {
   AwsIntegration,
   ServerInstance,
   LogEntry,
+  AlertLog,
 };

--- a/opsentra/src/routes/alert.routes.js
+++ b/opsentra/src/routes/alert.routes.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const express = require('express');
+const { protect } = require('../middleware/auth');
+const { getAlertHistory } = require('../controllers/alertController');
+
+const router = express.Router();
+
+router.use(protect);
+
+/**
+ * GET /api/v1/alerts
+ * Paginated alert history for a workspace.
+ * ?workspace_id= &page= &limit=
+ */
+router.get('/', getAlertHistory);
+
+module.exports = router;

--- a/opsentra/src/routes/index.js
+++ b/opsentra/src/routes/index.js
@@ -10,6 +10,7 @@ const awsRoutes = require('./aws.routes');
 const serverRoutes = require('./server.routes');
 const agentRoutes = require('./agent.routes');
 const logsRoutes = require('./logs.routes');
+const alertRoutes = require('./alert.routes');
 
 const router = express.Router();
 const API_PREFIX = `/api/${config.server.apiVersion}`;
@@ -25,6 +26,7 @@ router.use(`${API_PREFIX}/aws`, awsRoutes);
 router.use(`${API_PREFIX}/servers`, serverRoutes);
 router.use(`${API_PREFIX}/agent`, agentRoutes);
 router.use(`${API_PREFIX}/logs`, logsRoutes);
+router.use(`${API_PREFIX}/alerts`, alertRoutes);
 
 // ── API Root Info ─────────────────────────────────────────
 router.get(API_PREFIX, (req, res) => {

--- a/opsentra/src/services/alertService.js
+++ b/opsentra/src/services/alertService.js
@@ -15,6 +15,7 @@
 
 const Workspace = require('../models/Workspace');
 const User = require('../models/User');
+const AlertLog = require('../models/AlertLog');
 const { getRedisClient } = require('../config/redis');
 const { queueRawEmail } = require('../workers/emailWorker');
 const { analyseErrors } = require('./aiAnalysisService');
@@ -195,6 +196,21 @@ const fireAlerts = async (workspaceId, logDocs) => {
 
   // 7. Set cooldown so inbox is not flooded
   await setCooldown(workspaceId);
+
+  // 8. Persist alert record for history page (fire-and-forget — never blocks email)
+  AlertLog.create({
+    workspaceId,
+    errorCount: errorLogs.length,
+    emailSentTo: user.email,
+    emailQueued: true,
+    sampleMessages: errorLogs.slice(0, 3).map((l) => l.message?.slice(0, 300) ?? ''),
+    aiCause:    analysis?.cause    ?? null,
+    aiFix:      analysis?.fix      ?? null,
+    aiSeverity: analysis?.severity ?? null,
+    aiSummary:  analysis?.summary  ?? null,
+  }).catch((err) =>
+    logger.error(`[AlertService] Failed to save AlertLog: ${err.message}`),
+  );
 
   logger.info(
     `[AlertService] Alert email queued for ${user.email} ` +


### PR DESCRIPTION
Persists every fired alert to MongoDB (AlertLog). Exposes a paginated GET /api/v1/alerts endpoint. Adds an Alert History page to the dashboard showing severity, AI root-cause analysis, suggested fix command, and sample log messages with expand/collapse per alert. Nav item added to sidebar under Logs Viewer.